### PR TITLE
공유페이지 헤더 모바일 반응형 추가 및 푸터 기존 링크 삭제

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -10,7 +10,9 @@ export function Footer() {
             <Link to="#">이용약관</Link>
             <Link to="#">개인정보처리방침</Link>
           </div>
-          <p className="text-[13px] font-[400] text-gray-50">© 2025 linkmoa</p>
+          <p className="text-[13px] font-[400] text-gray-50">
+            © 2025 linkpoket
+          </p>
         </div>
       </div>
     </footer>

--- a/src/components/footer/FooterLanding.tsx
+++ b/src/components/footer/FooterLanding.tsx
@@ -1,12 +1,12 @@
 import { Link } from 'react-router-dom';
-import Logo from '@/assets/widget-ui-assets/Logo.svg?react';
+import Logo from '@/public/LinkLogo.svg?react';
 
 export function FooterLanding() {
   return (
     <footer>
       <div className="flex w-full items-center justify-between px-[22px] py-[32px]">
         <div className="flex items-center gap-[32px]">
-          <Logo />
+          {/* <Logo /> */}
           <span className="text-gray-90 text-[13px] font-[500]">
             © 2025 linkmoa
           </span>

--- a/src/components/page-layout-ui/SharedPageHeaderSection.tsx
+++ b/src/components/page-layout-ui/SharedPageHeaderSection.tsx
@@ -3,6 +3,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import useUpdateSharedPageTitle from '@/hooks/mutations/useUpdateSharedPageTitle';
 import { useModalStore } from '@/stores/modalStore';
 import { useLocation } from 'react-router-dom';
+import { useMobile } from '@/hooks/useMobile';
 import { useFolderColorStore } from '@/stores/folderColorStore';
 import { Button } from '../common-ui/button';
 
@@ -19,13 +20,17 @@ export default function SharedPageHeaderSection({
 }: PageHeaderSectionProps) {
   const [title, setTitle] = useState(pageTitle ?? '');
   const lastUpdateTitle = useRef({ title });
-  const { openLinkModal, openFolderModal } = useModalStore();
-  const { getCurrentColor } = useFolderColorStore();
-  const currentFolderColor = getCurrentColor();
-  const { mutate: updateSharedPageTitle } = useUpdateSharedPageTitle(pageId);
+
   const location = useLocation();
   const currentLocation = location.pathname;
   const isLinkButtonVisible = currentLocation !== '/bookmarks';
+  const isMobile = useMobile();
+
+  const { openLinkModal, openFolderModal } = useModalStore();
+  const { getCurrentColor } = useFolderColorStore();
+  const currentFolderColor = getCurrentColor();
+
+  const { mutate: updateSharedPageTitle } = useUpdateSharedPageTitle(pageId);
 
   const updateSharedPageTitleImmediately = () => {
     if (!pageId) return;
@@ -85,7 +90,9 @@ export default function SharedPageHeaderSection({
           className={`outline-nonetext-gray-90' } inline-block w-full text-[22px] font-bold`}
         />
         {isLinkButtonVisible && (
-          <div className="flex items-center gap-[8px]">
+          <div
+            className={`flex items-center gap-[8px] ${isMobile ? 'hidden' : ''}`}
+          >
             <Button
               size="sm"
               style={{

--- a/src/pages/landing/sections/Footer.tsx
+++ b/src/pages/landing/sections/Footer.tsx
@@ -1,4 +1,3 @@
-import FooterLogo from '@/assets/common-ui-assets/FooterLogo.svg?react';
 import { PRIVACY_POLICY } from '@/constants/privacyPolicy';
 import { TERMS_OF_SERVICE } from '@/constants/termsOfService';
 import { Link } from 'react-router-dom';
@@ -21,7 +20,7 @@ const Footer: React.FC = () => {
   return (
     <footer className="footer-mobile footer-tablet footer-desktop flex justify-between">
       <div className="footer-logo-container-mobile footer-logo-container-desktop footer-logo-container-tablet flex items-center space-x-8">
-        <FooterLogo />
+        {/* <FooterLogo /> */}
         <p className="text-gray-90 footer-copyright-mobile footer-copyright-tablet footer-copyright-desktop text-[21px] font-medium">
           © 2025 Linkpoket
         </p>


### PR DESCRIPTION
- 공유페이지 header에 모바일 반응형에 따른 버튼 hidden 적용
- 랜딩페이지 기존 상호로고 제거
